### PR TITLE
Center dropdown

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -123,7 +123,7 @@ export default class LauncherExtension extends Extension {
     }
 
     _addIndicator() {
-        this._indicator = new PanelMenu.Button(0.0, this.metadata.name, false);
+        this._indicator = new PanelMenu.Button(0.5, this.metadata.name, false);
 
         const icon = new St.Icon({
             gicon: new Gio.ThemedIcon({ name: ICON }),


### PR DESCRIPTION
In recent Gnome versions the dropdown menus on the panel are center aligned to their button. With this change launcher will follow this new convention.

Before:
![launcher_before](https://github.com/hedgieinsocks/launcher/assets/1271737/2283cb1f-23f0-412d-b4b5-dc4f843f6b76)

After:
![launcher_after](https://github.com/hedgieinsocks/launcher/assets/1271737/9817703e-89c2-4e5d-afc1-092345ccf85f)
